### PR TITLE
Updating dnabot from version 3.1.0 to 4.1.0

### DIFF
--- a/tools/dnabot/dnabot.xml
+++ b/tools/dnabot/dnabot.xml
@@ -1,7 +1,7 @@
 <tool id="dnabot" name="DNA-Bot" version="@TOOL_VERSION@" profile="21.09">
     <description>DNA assembly using BASIC on OpenTrons</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.1.0</token>
+        <token name="@TOOL_VERSION@">4.1.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">dnabot</requirement>

--- a/tools/dnabot/dnabot.xml
+++ b/tools/dnabot/dnabot.xml
@@ -1,4 +1,4 @@
-<tool id="dnabot" name="DNA-Bot" version="@TOOL_VERSION@" profile="21.09" licence="MIT">
+<tool id="dnabot" name="DNA-Bot" version="@TOOL_VERSION@" profile="21.09" license="MIT">
     <description>DNA assembly using BASIC on OpenTrons</description>
     <macros>
         <token name="@TOOL_VERSION@">4.1.0</token>

--- a/tools/dnabot/dnabot.xml
+++ b/tools/dnabot/dnabot.xml
@@ -1,4 +1,4 @@
-<tool id="dnabot" name="DNA-Bot" version="@TOOL_VERSION@" profile="21.09">
+<tool id="dnabot" name="DNA-Bot" version="@TOOL_VERSION@" profile="21.09" licence="MIT">
     <description>DNA assembly using BASIC on OpenTrons</description>
     <macros>
         <token name="@TOOL_VERSION@">4.1.0</token>
@@ -63,7 +63,7 @@
             <param name="plate_files" value="user_parts_coords.csv,linker_parts_coords.csv"/>
             <output name="dnabot_scripts" ftype="tar">
                 <assert_contents>
-                    <has_size value="153600" delta="10000"/>
+                    <has_size value="165900" delta="10000"/>
                 </assert_contents>
             </output>
         </test>
@@ -99,22 +99,11 @@ Ouput
 
 * **Dnabot scripts**: DNA-Bot scripts in TAR format which implement the 4 assembly steps and metainformation to keep track of parameters.
 
-Version
--------
-
-3.1.0
-
 Authors
 -------
 
 * **Matthew C Haines**
 * Thomas Duigou
-
-License
--------
-
-`MIT <https://github.com/BASIC-DNA-ASSEMBLY/DNA-BOT/blob/master/LICENSE>`_
-
 
 Acknowledgments
 ---------------


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **dnabot**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated dnabot from version 3.1.0 to 4.1.0.

**Project home page:** https://github.com/brsynth/DNA-BOT/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).