### PR TITLE
Updating retropath2_wrapper from version 3.1.0 to 3.1.1

### DIFF
--- a/tools/retropath2_wrapper/retropath2_wrapper.xml
+++ b/tools/retropath2_wrapper/retropath2_wrapper.xml
@@ -2,7 +2,7 @@
     <description>Build a reaction network from a set of source compounds to a set of sink compounds</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">3.1.0</token>
+        <token name="@TOOL_VERSION@">3.1.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">retropath2_wrapper</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **retropath2_wrapper**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated retropath2_wrapper from version 3.1.0 to 3.1.1.

**Project home page:** https://github.com/brsynth/retropath2_wrapper/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).