### PR TITLE
Updating straindesign from version 3.2.2 to 3.2.3

### DIFF
--- a/tools/straindesign/analyzing-model.xml
+++ b/tools/straindesign/analyzing-model.xml
@@ -4,9 +4,10 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
+    <!--
     <expand macro="stdio"/>
+    -->
     <command detect_errors="exit_code"><![CDATA[
-        ## Run cmdline
         python -m straindesign analyzing-model
             @CMD_INPUT_MODEL@
             @CMD_INPUT_MEDIUM@

--- a/tools/straindesign/macros.xml
+++ b/tools/straindesign/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!--  GLOBAL  -->
-    <token name="@TOOL_VERSION@">3.2.2</token>
+    <token name="@TOOL_VERSION@">3.2.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@LICENSE@">MIT</token>
     <xml name="requirements">

--- a/tools/straindesign/reduce-model.xml
+++ b/tools/straindesign/reduce-model.xml
@@ -4,7 +4,9 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
+    <!--
     <expand macro="stdio"/>
+    -->
     <command detect_errors="exit_code"><![CDATA[
         python -m straindesign reduce-model
             @CMD_INPUT_MODEL@

--- a/tools/straindesign/simulate-deletion.xml
+++ b/tools/straindesign/simulate-deletion.xml
@@ -4,7 +4,9 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
+    <!--
     <expand macro="stdio"/>
+    -->
     <command detect_errors="exit_code"><![CDATA[
         python -m straindesign simulate-deletion
             @CMD_INPUT_MODEL@


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **straindesign**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated straindesign from version 3.2.2 to 3.2.3.

**Project home page:** https://github.com/brsynth/straindesign/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).