### PR TITLE
Updating retropath2 from version 3.1.1 to 3.2.0

### DIFF
--- a/tools/retropath2/retropath2_wrapper.xml
+++ b/tools/retropath2/retropath2_wrapper.xml
@@ -29,6 +29,9 @@
             --dmax '$adv.dmax'
             --mwmax_source '$adv.mwmax_source'
             --kinstall "\${TMPDIR:-.}"
+            #if str($adv.network) == "true":
+                --no-network
+            #end if
             --msc_timeout '$adv.timeout' &&
         if compgen -G 'out/*_scope.csv' > /dev/null; then
             cp out/*_scope.csv '$Reaction_Network';
@@ -57,6 +60,7 @@
             <param name="dmax" type="integer" value="1000" min="0" max="1000" label="Maximum rule diameter" help="Maximum rule diameter of the sphere including the atoms around the reacting center. The higher is the diameter, the more specific are the rules."/>
             <param name="mwmax_source" type="integer" value="1000" min="0" max="2000" label="Molecular weight of source (Da)" help="The molecular weight cutoff (in Da), above which initial source (ie target) and intermediate compounds will be filtered out." />
             <param name="timeout" type="integer" value="60" min="30" max="600" label="Timeout (min)" help="Maximal time of RetroPath2.0 execution (60 minutes by default)." />
+            <param name="network" type="boolean" checked="false" label="Do not use network" />
         </section>
     </inputs>
     <outputs>

--- a/tools/retropath2/retropath2_wrapper.xml
+++ b/tools/retropath2/retropath2_wrapper.xml
@@ -2,7 +2,7 @@
     <description>Build a reaction network from a set of source compounds to a set of sink compounds</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">3.1.1</token>
+        <token name="@TOOL_VERSION@">3.2.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">retropath2_wrapper</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **retropath2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated retropath2 from version 3.1.1 to 3.2.0.

**Project home page:** https://github.com/brsynth/retropath2_wrapper/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).