### PR TITLE
Updating doe_synbio from version 2.6.0 to 2.7.1

### DIFF
--- a/tools/doe_synbio/sampler.xml
+++ b/tools/doe_synbio/sampler.xml
@@ -2,7 +2,7 @@
     <description>Generate Latin Hypercube Samples for given components.</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@TOOL_VERSION@">2.6.0</token>
+        <token name="@TOOL_VERSION@">2.7.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">icfree</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **doe_synbio**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated doe_synbio from version 2.6.0 to 2.7.1.

**Project home page:** https://github.com/brsynth/icfree-ml/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).