### PR TITLE
Updating icfree from version 2.7.0 to 2.7.1

### DIFF
--- a/tools/icfree/macros.xml
+++ b/tools/icfree/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.7.0</token>
+    <token name="@TOOL_VERSION@">2.7.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **icfree**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated icfree from version 2.7.0 to 2.7.1.

**Project home page:** https://github.com/brsynth/icfree-ml/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).