### PR TITLE
Updating rrparser from version 2.5.2 to 2.6.0

### DIFF
--- a/tools/rrparser/rrparser.xml
+++ b/tools/rrparser/rrparser.xml
@@ -2,7 +2,7 @@
     <description>Retrieve the reaction rules from RetroRules</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">2.5.2</token>
+        <token name="@TOOL_VERSION@">2.6.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">rrparser</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **rrparser**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated rrparser from version 2.5.2 to 2.6.0.

**Project home page:** https://github.com/brsynth/rrparser/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).