### PR TITLE
Updating molecule-signature from version 2.1.0 to 2.1.1

### DIFF
--- a/tools/molecule-signature/macros.xml
+++ b/tools/molecule-signature/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.1.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.1.1</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">molecule-signature</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **molecule-signature**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated molecule-signature from version 2.1.0 to 2.1.1.

**Project home page:** https://github.com/brsynth/molecule-signature/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).