### PR TITLE
Updating retropath2 from version 3.3.1 to 3.4.0

### DIFF
--- a/tools/retropath2/retropath2_wrapper.xml
+++ b/tools/retropath2/retropath2_wrapper.xml
@@ -1,8 +1,8 @@
 <tool id="retropath2" name="RetroPath2.0" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.09" license="MIT">
     <description>Build a reaction network from a set of source compounds to a set of sink compounds</description>
     <macros>
-        <token name="@VERSION_SUFFIX@">1</token>
-        <token name="@TOOL_VERSION@">3.3.1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@TOOL_VERSION@">3.4.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">retropath2_wrapper</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **retropath2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated retropath2 from version 3.3.1 to 3.4.0.

**Project home page:** https://github.com/brsynth/retropath2_wrapper/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).