### PR TITLE
Updating retropath2 from version 3.4.0 to 3.5.0

### DIFF
--- a/tools/retropath2/retropath2_wrapper.xml
+++ b/tools/retropath2/retropath2_wrapper.xml
@@ -2,7 +2,7 @@
     profile="21.09" license="MIT">
     <description>Build a reaction network from a set of source compounds to a set of sink compounds</description>
     <macros>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@TOOL_VERSION@">3.5.0</token>
     </macros>
     <requirements>
@@ -10,27 +10,20 @@
     </requirements>
     <stdio>
         <!-- Fatal -->
-        <exit_code range="1" level="fatal" description="Cannot find source-in-sink file" />
         <regex match="It seems that the target product is already in the chassis" source="both"
-            level="fatal" description="It seems that the target product is already in the chassis" />
-        <exit_code range="2" level="fatal"
-            description="Running the RetroPath2.0 Knime program produced an OSError" />
+            level="fatal"
+            description="It seems that the target product is already in the chassis (Exit code: 1)" />
         <regex match="The following error occured" source="both" level="fatal"
-            description="The following error occured" />
-        <exit_code range="3" level="fatal" description="The InChI string is malformed" />
+            description="The following error occured (Exit code: 2)" />
         <regex match="is not a valid InChI notation" source="both" level="fatal"
-            description="is not a valid InChI notation" />
-        <exit_code range="4" level="fatal" description="Sink file is malformed" />
+            description="is not a valid InChI notation (Exit code: 3)" />
         <regex match="The sink file is malformed" source="both" level="fatal"
-            description="The sink file is malformed" />
-        <exit_code range="5" level="fatal" description="Knime installation error" />
+            description="The sink file is malformed (Exit code: 4)" />
         <!-- Warning -->
-        <exit_code range="10" level="warning" description="Source has been found in the sink" />
         <regex match="Source has been found in the sink" source="both" level="warning"
-            description="Source has been found in the sink" />
-        <exit_code range="11" level="warning" description="RetroPath2.0 has found no solution" />
+            description="Source has been found in the sink (Exit code: 10)" />
         <regex match="No solution has been found" source="both" level="warning"
-            description="No solution has been found" />
+            description="No solution has been found (Exit code: 11)" />
     </stdio>
     <command detect_errors="exit_code"><![CDATA[
         #if $sink.emptysink:
@@ -55,11 +48,7 @@
                 --quiet
             #end if
             --msc_timeout '$adv.timeout' &&
-        if compgen -G 'out/*_scope.csv' > /dev/null; then
-            cp out/*_scope.csv '$Reaction_Network';
-        else
-            cp out/results.csv '$Reaction_Network';
-        fi
+        cp out/*_scope.csv "$Reaction_Network" 2>/dev/null || cp out/results.csv "$Reaction_Network"
     ]]></command>
     <inputs>
         <param name="rulesfile" type="data" format="csv,tar" label="Rules File"


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **retropath2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated retropath2 from version 3.4.0 to 3.4.1.

**Project home page:** https://github.com/brsynth/retropath2_wrapper/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).