### PR TITLE
Updating rptools from version 6.5.0 to 6.6.4

### DIFF
--- a/tools/rptools/macros.xml
+++ b/tools/rptools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">6.5.0</token>
+    <token name="@TOOL_VERSION@">6.6.4</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **rptools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated rptools from version 6.5.0 to 6.6.4.

**Project home page:** https://github.com/brsynth/rptools/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).