### PR TITLE
Updating selenzy_wrapper from version 0.3.0 to 0.3.1

### DIFF
--- a/tools/selenzy_wrapper/selenzy_wrapper.xml
+++ b/tools/selenzy_wrapper/selenzy_wrapper.xml
@@ -2,7 +2,7 @@
     <description>Performs enzyme selection from a reaction query</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">0.3.0</token>
+        <token name="@TOOL_VERSION@">0.3.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">selenzy_wrapper</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **selenzy_wrapper**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated selenzy_wrapper from version 0.3.0 to 0.3.1.

**Project home page:** https://github.com/brsynth/selenzy-wrapper/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).